### PR TITLE
7/imp/fix resume layout for smaller screens

### DIFF
--- a/frontend/src/containers/resume/ResumePage.tsx
+++ b/frontend/src/containers/resume/ResumePage.tsx
@@ -17,15 +17,12 @@ const ResumePage = () => {
   );
 
   return (
-    <div className="bg-gray-400 min-h-screen">
-      <div className="container mx-auto pt-8 px-2">
+    <div className="bg-gray-400 min-h-screen pt-6">
+      <div className="container mx-auto px-4">
         {resume && <ResumeTitle color="blue" resume={resume} />}
-        <div className="resume-wrapper mx-auto">
+        <div className="resume-wrapper flex justify-center">
           {resumeQuery.isSuccess && resume ? (
-            <Resume
-              className={"flex flex-col items-center content-center"}
-              file={resume.url}
-            />
+            <Resume file={resume.url} />
           ) : (
             <Box
               sx={{

--- a/frontend/src/containers/resume/components/Resume.tsx
+++ b/frontend/src/containers/resume/components/Resume.tsx
@@ -1,24 +1,25 @@
 import React, { useCallback, useState } from "react";
 
 import { Button } from "@mui/material";
-import classNames from "classnames";
 import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/esm/Page/AnnotationLayer.css";
+import styled from "styled-components";
+import tw from "tailwind-styled-components";
 
 import ZoomButtons from "../../../components/ZoomButtons";
 import { isMobile } from "../../../utils";
 
 type Props = {
   file: Blob | string;
-  className?: string;
 };
 
-const Resume = ({ file, className }: Props) => {
+const Resume = ({ file }: Props) => {
   const [numPages, setNumPages] = useState<number>(0);
   const [pageNumber, setPageNumber] = useState(1);
   const [zoom, setZoom] = useState<number>(1.25);
   const documentWidth = window.innerWidth;
-  const pageWidth = isMobile() ? documentWidth + 100 : documentWidth / 2.25;
+  const mobileScreen = isMobile();
+  const pageWidth = mobileScreen ? documentWidth / 1.35 : documentWidth / 2.25;
 
   pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
 
@@ -40,10 +41,10 @@ const Resume = ({ file, className }: Props) => {
 
   const handlePageZoom = useCallback(
     (zoom: number) => {
-      const zoomLevel = isMobile() ? 0.75 : zoom;
+      const zoomLevel = mobileScreen ? 0.75 : zoom;
       setZoom(zoomLevel);
     },
-    [setZoom],
+    [mobileScreen],
   );
 
   const handlePageButton = useCallback(() => {
@@ -52,31 +53,25 @@ const Resume = ({ file, className }: Props) => {
   }, [numPages, pageNumber, setPageNumber]);
 
   return (
-    <div className="container mx-auto px-lg-10">
-      <Document
-        file={file}
-        onLoadSuccess={onDocumentLoadSuccess}
-        className="relative flex flex-col items-center pb-16 "
-      >
-        <div className="relative">
-          <Page
-            className={className}
-            pageNumber={pageNumber}
-            onLoadSuccess={removeTextLayerOffset}
-            scale={zoom}
-            width={pageWidth}
-          />
+    <Document
+      file={file}
+      onLoadSuccess={onDocumentLoadSuccess}
+      renderMode="canvas"
+      className="w-fit min-h-300"
+    >
+      <div className="relative">
+        <Page
+          pageNumber={pageNumber}
+          onLoadSuccess={removeTextLayerOffset}
+          scale={zoom}
+          width={pageWidth}
+        />
+        <div className="hidden md:block">
           <ZoomButtons onZoom={handlePageZoom} />
         </div>
-        <div
-          className={classNames(
-            "button-groups flex content-between items-center space-x-4",
-            {
-              "-mt-16": zoom > 0.75,
-              "mt-4": zoom < 0.75,
-            },
-          )}
-        >
+      </div>
+      <ButtonContainer isMobile={mobileScreen}>
+        <ButtonGroup zoom={zoom}>
           <Button
             size="small"
             variant="contained"
@@ -98,10 +93,28 @@ const Resume = ({ file, className }: Props) => {
           >
             Next
           </Button>
-        </div>
-      </Document>
-    </div>
+        </ButtonGroup>
+      </ButtonContainer>
+    </Document>
   );
 };
 
 export default Resume;
+
+const ButtonContainer = styled.div<{ isMobile: boolean }>`
+  display: flex;
+  justify-content: center;
+  margin-top: ${(props) => (props.isMobile ? "60px" : "20px")};
+  margin-bottom: 30px;
+`;
+ButtonContainer.displayName = "ButtonContainer";
+
+const ButtonGroup = tw.div<{ zoom: number }>`
+button-groups
+flex content-between
+items-center
+space-x-4
+${(props) => props.zoom > 0.75 && "-mt-16"}
+${(props) => props.zoom < 0.75 && "mt-4"}
+`;
+ButtonGroup.displayName = "ButtonGroup";

--- a/frontend/src/containers/resume/components/ResumeTitle.tsx
+++ b/frontend/src/containers/resume/components/ResumeTitle.tsx
@@ -12,9 +12,9 @@ type TitleProp = {
 };
 
 const TitleContainer = tw.div<TitleProp>`
-flex
-items-center
-justify-between
+md:flex
+md:items-center
+md:justify-between
 self-center
 bg-white
 border-t-4
@@ -36,6 +36,7 @@ const ResumeTitle = ({ color = "blue", resume }: Props) => {
   return (
     <TitleContainer color={color}>
       <h2 className="text-3xl text-gray-600 text-center font-bold">Resume</h2>
+        <div className="flex justify-between items-center space-x-4 md:w-2/3  mt-4 md:mt-0">
       <Button
         className="text-white font-bold"
         color="primary"
@@ -46,12 +47,13 @@ const ResumeTitle = ({ color = "blue", resume }: Props) => {
       >
         Download
       </Button>
-      <p className="text-gray-600  font-semibold">
-        last modified:{" "}
-        <span className="text-gray-400">
+      <div className="md:flex text-center text-gray-600 font-semibold">
+          <p>last modified:</p>
+        <p className="text-gray-400 ml-2">
           {DateTime.fromISO(resume.updated_at).toFormat("MMMM d, yyyy")}
-        </span>
-      </p>
+        </p>
+      </div>
+        </div>
     </TitleContainer>
   );
 };


### PR DESCRIPTION
Personal-Portfolio: #7

This PR adds responsiveness to the Resume page and fixes the resume layout on smaller screens.

### Changes
---

* Remove **zoom** feature for smaller screens.
* Fixes resume overflowing off the page.


![Screenshot 2023-06-09 at 11 09 43 PM](https://github.com/cbedroid/personal-portfolio/assets/54720725/4768d681-4077-4f5e-aaf8-277d3c75ac59)

---

![Screenshot 2023-06-09 at 11 10 07 PM](https://github.com/cbedroid/personal-portfolio/assets/54720725/7fcc3f26-1b8e-412a-91ab-ba9d309dbd72)


